### PR TITLE
chore:introduce local setup command and update cache target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,17 @@ isort: # Run isort
 secrets-baseline: # Generate a new secrets baseline file
 	poetry run detect-secrets scan > .secrets.baseline
 
-rebuild_cache_man:
+rebuild_cache:
 	export PYTHONPATH=./fbr && \
 	export DJANGO_SETTINGS_MODULE='fbr.config.settings.local' && \
 	export DATABASE_URL=postgres://postgres:postgres@localhost:5432/fbr && \
 	poetry install && \
 	poetry run rebuild-cache
+
+setup_local: # Set up the local environment
+	@echo "$(COLOUR_GREEN)Running initial setup for local environment...$(COLOUR_NONE)"
+	$(MAKE) first-use
+	$(MAKE) start
+	$(MAKE) migrate
+	$(MAKE) rebuild_cache
+	@echo "$(COLOUR_GREEN)Local setup complete.$(COLOUR_NONE)"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,12 @@ With your Poetry shell active:
 > Code quality checks are also performed when pushing your code to origin
 > but pre-commit hooks catch issues early and will improve Developer Experience.
 
-### Update database tables
+### Setup the service, database and cache locally
+
+    $ make setup_local
+
+
+### Update database tables (manually)...do not use unless you know what you are doing
 
 > To update local database tables, you need to set the `DATABASE_URL` environment variable. You can set it in the terminal or in the `.env` file.
 


### PR DESCRIPTION
This commit adds a new 'setup_local' command to the Makefile for setting up the service, database, and cache locally, providing a convenient way to initialize the development environment. Additionally, it renames 'rebuild_cache_man' to 'rebuild_cache' for clarity and updates the README to reflect these changes. These adjustments aim to enhance developer efficiency and streamline the onboarding process.