### PR TITLE
chore:add Celery and Django Celery Beat configuration

### DIFF
--- a/fbr/cache/tasks.py
+++ b/fbr/cache/tasks.py
@@ -8,7 +8,7 @@ from fbr.search.config import SearchDocumentConfig
 from fbr.search.utils.documents import clear_all_documents
 
 
-@shared_task()
+@shared_task(binding=True)
 def rebuild_cache():
     try:
         start = time.time()

--- a/fbr/config/settings/base.py
+++ b/fbr/config/settings/base.py
@@ -63,7 +63,6 @@ LOCAL_APPS = [
 
 THIRD_PARTY_APPS: list = [
     "webpack_loader",
-    "django_celery_beat",
 ]
 
 INSTALLED_APPS = DJANGO_APPS + LOCAL_APPS + THIRD_PARTY_APPS

--- a/fbr/config/settings/base.py
+++ b/fbr/config/settings/base.py
@@ -47,6 +47,7 @@ ENVIRONMENT = env(
 
 # Application definition
 DJANGO_APPS = [
+    "django_celery_beat",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -136,6 +137,18 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",  # noqa: E501
     },
 ]
+
+REDIS_ENDPOINT = env("REDIS_ENDPOINT", default="")
+
+# Celery
+CELERY_BROKER_URL = env("REDIS_ENDPOINT", default="")
+if CELERY_BROKER_URL and CELERY_BROKER_URL.startswith("rediss://"):
+    CELERY_BROKER_URL = f"{CELERY_BROKER_URL}?ssl_cert_reqs=CERT_REQUIRED"
+CELERY_RESULT_BACKEND = CELERY_BROKER_URL
+CELERY_ACCEPT_CONTENT = ["application/json"]
+CELERY_RESULT_SERIALIZER = "json"
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers.DatabaseScheduler"
 
 # Internationalisation
 LANGUAGE_CODE = "en-gb"


### PR DESCRIPTION
Integrate Celery into the project by configuring broker and result backend with Redis, adding necessary settings, and setting up periodic task scheduling with Django Celery Beat. The rebuild_cache task is now a bound task, allowing it to access task-specific features. Additionally, configuration changes in the Celery app include environment setup and periodic task scheduling.