### PR TITLE
fix: document count logic and ensure valid sort dates.

### DIFF
--- a/fbr/cache/legislation.py
+++ b/fbr/cache/legislation.py
@@ -216,6 +216,9 @@ class Legislation:
         Returns:
         dict: A dictionary containing the item details in a structured format.
         """
+
+        valid_sort_date = modified if valid is None or valid == "" else valid
+
         return {
             "id": generate_short_uuid(),
             "title": title,
@@ -233,8 +236,8 @@ class Legislation:
             "description": description if description is not None else "",
             "date_issued": convert_date_string_to_obj(modified),
             "date_modified": convert_date_string_to_obj(modified),
-            "date_valid": valid,
-            "sort_date": convert_date_string_to_obj(valid),
+            "date_valid": valid_sort_date,
+            "sort_date": valid_sort_date,
             "type": "Legislation",
             "score": 0,
         }

--- a/fbr/cache/public_gateway.py
+++ b/fbr/cache/public_gateway.py
@@ -69,7 +69,7 @@ class PublicGateway:
             # Now you can use `data` as a usual Python dictionary
             # Convert each row into DataResponseModel object
             total_documents = len(data.get("uk_regulatory_documents"))
-            inserted_document_count = 0
+            inserted_document_count = 1
             for row in data.get("uk_regulatory_documents"):
                 logger.info(
                     f"inserting or updating document "


### PR DESCRIPTION
Updated the initial value of `inserted_document_count` to 1 to more accurately reflect insertion logic. Introduced `valid_sort_date` in `legislation.py` to default to `modified` date if `valid` date is missing or empty, ensuring correct sorting behavior.