### PR TITLE
fix: Correct Django settings module path in Celery config

### DIFF
--- a/fbr/config/celery.py
+++ b/fbr/config/celery.py
@@ -4,7 +4,7 @@ from celery import Celery
 from celery.schedules import crontab
 from dbt_copilot_python.celery_health_check import healthcheck
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fbr.config.settings.local")
 
 celery_app = Celery("fbr_celery")
 celery_app.config_from_object("django.conf:settings", namespace="CELERY")


### PR DESCRIPTION
<details>
<summary>Details</summary>

- Updated path from "config.settings.local" to "fbr.config.settings.local"
- Ensures Celery uses correct settings, reducing misconfiguration errors
</details>