### PR TITLE
Set Django settings for Celery configuration

### DIFF
--- a/fbr/config/celery.py
+++ b/fbr/config/celery.py
@@ -1,6 +1,10 @@
+import os
+
 from celery import Celery
 from celery.schedules import crontab
 from dbt_copilot_python.celery_health_check import healthcheck
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
 
 celery_app = Celery("fbr_celery")
 


### PR DESCRIPTION
This pull request updates the Celery configuration to use the local settings module, ensuring consistency and simplifying the setup process.