### PR TITLE
chore:set Celery to UTC and fix settings module path.

### DIFF
--- a/fbr/config/celery.py
+++ b/fbr/config/celery.py
@@ -4,7 +4,7 @@ from celery import Celery
 from celery.schedules import crontab
 from dbt_copilot_python.celery_health_check import healthcheck
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fbr.config.settings.local")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
 
 celery_app = Celery("fbr_celery")
 

--- a/fbr/config/settings/base.py
+++ b/fbr/config/settings/base.py
@@ -155,6 +155,8 @@ CELERY_TASK_TIME_LIMIT = (
 CELERY_TASK_SOFT_TIME_LIMIT = (
     270  # Optional: Grace period before forced termination
 )
+CELERY_TIMEZONE = "UTC"
+CELERY_ENABLE_UTC = True
 
 # Internationalisation
 LANGUAGE_CODE = "en-gb"


### PR DESCRIPTION
Added UTC settings for Celery to ensure task scheduling consistency across environments. Corrected the DJANGO_SETTINGS_MODULE path for Celery configuration, aligning it with the project's structure. These changes help improve maintainability and prevent timezone-related issues.