### PR TITLE
refactor:module paths and refine Celery configuration.

### DIFF
--- a/fbr/cache/tasks.py
+++ b/fbr/cache/tasks.py
@@ -8,7 +8,7 @@ from fbr.search.config import SearchDocumentConfig
 from fbr.search.utils.documents import clear_all_documents
 
 
-@shared_task(bind=True, max_retries=3)
+@shared_task
 def rebuild_cache():
     try:
         start = time.time()

--- a/fbr/config/celery.py
+++ b/fbr/config/celery.py
@@ -4,11 +4,11 @@ from celery import Celery
 from celery.schedules import crontab
 from dbt_copilot_python.celery_health_check import healthcheck
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fbr.config.settings.local")
 
 celery_app = Celery("fbr_celery")
 
-celery_app.config_from_object("django.conf:settings", namespace="CELERY")
+celery_app.config_from_object("fbr.config.settings.local", namespace="CELERY")
 
 celery_app.autodiscover_tasks()
 

--- a/fbr/config/settings/local.py
+++ b/fbr/config/settings/local.py
@@ -6,7 +6,7 @@ from .base import *  # noqa
 BASE_APPS = [
     "whitenoise.runserver_nostatic",  # Serve static files via WhiteNoise
     "rest_framework",
-    "fbr.cache",
+    "cache",
 ]
 
 # REST_FRAMEWORK = {


### PR DESCRIPTION
refactor:module paths and refine Celery configuration.

Correct the import path for settings in Celery to ensure it uses the proper local configuration. Simplify the cache references by updating module names, ensuring clarity, and removing unnecessary task bindings for rebuild_cache. These changes improve code maintainability and readability while aligning with project structure standards.