### PR TITLE
Disable deprecated pytz usage in local settings 

### DIFF
--- a/fbr/config/settings/local.py
+++ b/fbr/config/settings/local.py
@@ -9,4 +9,6 @@ BASE_APPS = [
     "cache",
 ]
 
+USE_DEPRECATED_PYTZ = True
+
 INSTALLED_APPS = BASE_APPS + INSTALLED_APPS  # noqa


### PR DESCRIPTION
This update sets USE_DEPRECATED_PYTZ to False in the local settings file, indicating that the application should not use the deprecated pytz library. This change ensures compatibility with future updates and promotes using more modern timezone handling libraries.