### PR TITLE
Remove deprecated pytz usage and refactor Celery configuration

### DIFF
--- a/fbr/config/celery.py
+++ b/fbr/config/celery.py
@@ -4,7 +4,10 @@ from celery import Celery
 from celery.schedules import crontab
 from dbt_copilot_python.celery_health_check import healthcheck
 
+import django
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+django.setup()
 
 celery_app = Celery("fbr_celery")
 

--- a/fbr/config/settings/local.py
+++ b/fbr/config/settings/local.py
@@ -9,6 +9,4 @@ BASE_APPS = [
     "cache",
 ]
 
-USE_DEPRECATED_PYTZ = True
-
 INSTALLED_APPS = BASE_APPS + INSTALLED_APPS  # noqa


### PR DESCRIPTION
This pull request removes the deprecated pytz usage from the local settings file and refactors the Celery configuration for better performance and compatibility.