### PR TITLE
Initialize Django setup at the start of manage.py

### DIFF
--- a/fbr/config/celery.py
+++ b/fbr/config/celery.py
@@ -4,10 +4,7 @@ from celery import Celery
 from celery.schedules import crontab
 from dbt_copilot_python.celery_health_check import healthcheck
 
-import django
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
-django.setup()
 
 celery_app = Celery("fbr_celery")
 

--- a/fbr/manage.py
+++ b/fbr/manage.py
@@ -1,12 +1,19 @@
+# flake8: noqa
+
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+import django
+
+django.setup()
+
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
**Description:**
- Ensure Django setup is configured early in manage.py to avoid configuration issues during application start-up.
- Streamline initialization by relocating Django setup to the beginning of the file.
- Remove redundant Django setup in celery.py for improved efficiency.