### PR TITLE
Fix Django settings module path in Celery configuration

### DIFF
--- a/fbr/config/celery.py
+++ b/fbr/config/celery.py
@@ -4,7 +4,7 @@ from celery import Celery
 from celery.schedules import crontab
 from dbt_copilot_python.celery_health_check import healthcheck
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fbr.config.settings.local")
 
 celery_app = Celery("fbr_celery")
 


### PR DESCRIPTION
This pull request corrects the path for the DJANGO_SETTINGS_MODULE environment variable in the Celery configuration file. It ensures the application loads the correct settings module, preventing potential misconfigurations during runtime.