### PR TITLE
fix:commented out use Redis-based caching (commented for future implementation)

### DIFF
--- a/fbr/settings.py
+++ b/fbr/settings.py
@@ -202,11 +202,15 @@ WEBPACK_LOADER = {
 
 
 # TODO: Use redis for cache?
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-    }
-}
+# CACHES = {
+#     "default": {
+#         "BACKEND": "django_redis.cache.RedisCache",
+#         "LOCATION": f"redis://127.0.0.1:6379/1",
+#         "OPTIONS": {
+#             "CLIENT_CLASS": "django_redis.client.DefaultClient",
+#         },
+#     }
+# }
 
 # Logging
 LOGGING: dict[str, Any] = {


### PR DESCRIPTION
Replaced the local memory cache configuration with a commented Redis cache setup for future use. This prepares the settings file for an eventual transition to Redis as the caching backend.