### PR TITLE
chore:update cache app configuration with initialization logic

### DIFF
--- a/app/cache/apps.py
+++ b/app/cache/apps.py
@@ -2,6 +2,10 @@ from django.apps import AppConfig
 
 
 class CacheConfig(AppConfig):
-    name = "app.cache"
-    verbose_name = "Find business regulations core application functionality"
     default_auto_field = "django.db.models.BigAutoField"
+    name = "app.cache"
+    verbose_name = "Cache Functionality"
+
+    def ready(self):
+        # Custom app-specific initialization
+        print("Cache app is ready!")

--- a/fbr/settings.py
+++ b/fbr/settings.py
@@ -60,7 +60,7 @@ DJANGO_APPS = [
     "app",
     "app.core",
     "app.search",
-    "app.cache",
+    "app.cache.apps.CacheConfig",
     "celery_worker",
 ]
 


### PR DESCRIPTION
Replaced "app.cache" with "app.cache.apps.CacheConfig" in settings to use the updated AppConfig class. Added a `ready` method in `CacheConfig` for custom initialization and updated the verbose name to "Cache Functionality." This improves clarity and allows for app-specific setup during startup.