### PR TITLE
chore:remove poetry commands from deployment script

### DIFF
--- a/paas_entrypoint.sh
+++ b/paas_entrypoint.sh
@@ -3,5 +3,5 @@
 set -ex # Prints each command as it runs. If a command fails, it will halt at that point
 
 cd fbr || exit 1
-poetry run python manage.py migrate --noinput
-poetry run gunicorn config.wsgi --bind "0.0.0.0:$PORT"
+python manage.py migrate --noinput
+gunicorn config.wsgi --bind "0.0.0.0:$PORT"


### PR DESCRIPTION
Simplified the deployment process by removing the use of poetry for running commands. This eliminates unnecessary dependencies and ensures compatibility with environments lacking poetry installed.