### PR TITLE
update:Gunicorn command to use correct WSGI application path

### DIFF
--- a/fbr/settings.py
+++ b/fbr/settings.py
@@ -60,7 +60,7 @@ DJANGO_APPS = [
     "app",
     "app.core",
     "app.search",
-    "app.cache.apps.CacheConfig",
+    "app.cache",
     "celery_worker",
 ]
 

--- a/paas_entrypoint.sh
+++ b/paas_entrypoint.sh
@@ -2,6 +2,7 @@
 
 set -ex # Prints each command as it runs. If a command fails, it will halt at that point
 
-cd fbr || exit 1
 poetry run python manage.py migrate --noinput
-poetry run gunicorn config.wsgi --bind "0.0.0.0:$PORT"
+
+# Start the server
+poetry run gunicorn fbr.wsgi:application --bind "0.0.0.0:$PORT"


### PR DESCRIPTION
Revised the Gunicorn startup command to reference `fbr.wsgi:application` instead of `config.wsgi`. This ensures the correct WSGI application module is used when the server starts.