### PR TITLE
remove:Poetry usage from deployment script.

### DIFF
--- a/paas_entrypoint.sh
+++ b/paas_entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -ex # Prints each command as it runs. If a command fails, it will halt at that point
 
-poetry run python manage.py migrate --noinput
+python manage.py migrate --noinput
 
 # Start the server
-poetry run gunicorn fbr.wsgi:application --bind "0.0.0.0:$PORT"
+gunicorn fbr.wsgi:application --bind "0.0.0.0:$PORT"


### PR DESCRIPTION
Replaced Poetry commands with direct Python execution for migrations and server startup. Simplifies the script and removes dependency on Poetry for runtime execution.