### PR TITLE
refactor:database configuration to use dbt_copilot utility

### DIFF
--- a/fbr/settings.py
+++ b/fbr/settings.py
@@ -20,6 +20,7 @@ from typing import Any
 import dj_database_url
 import environ
 
+from dbt_copilot_python.database import database_url_from_env
 from django_log_formatter_asim import ASIMFormatter
 
 # Define the root directory (i.e. <repo-root>)
@@ -108,23 +109,28 @@ TEMPLATES = [
 WSGI_APPLICATION = "fbr.wsgi.application"
 
 DATABASES: dict = {}
-if DATABASE_URL := env("DATABASE_URL", default=None):
-    DATABASES = {
-        "default": {
-            **dj_database_url.parse(
-                DATABASE_URL,
-                engine="postgresql",
-            ),
-            "ENGINE": "django.db.backends.postgresql",
-        }
-    }
-else:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.sqlite3",
-            "NAME": BASE_DIR / "db.sqlite3",
-        }
-    }
+
+DATABASES["default"] = dj_database_url.config(  # noqa
+    default=database_url_from_env("DATABASE_CREDENTIALS")
+)
+
+# if DATABASE_URL := env("DATABASE_URL", default=None):
+#     DATABASES = {
+#         "default": {
+#             **dj_database_url.parse(
+#                 DATABASE_URL,
+#                 engine="postgresql",
+#             ),
+#             "ENGINE": "django.db.backends.postgresql",
+#         }
+#     }
+# else:
+#     DATABASES = {
+#         "default": {
+#             "ENGINE": "django.db.backends.sqlite3",
+#             "NAME": BASE_DIR / "db.sqlite3",
+#         }
+#     }
 
 AUTH_PASSWORD_VALIDATORS = [
     {


### PR DESCRIPTION
Replaced the existing database connection logic with the `database_url_from_env` utility from `dbt_copilot_python` for cleaner and more standardized configuration. Removed the previous fallback logic for SQLite, assuming consistent reliance on environment variables.