### PR TITLE
update:database configuration to explicitly set engine

### DIFF
--- a/fbr/settings.py
+++ b/fbr/settings.py
@@ -17,7 +17,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-import dj_database_url
 import environ
 
 from dbt_copilot_python.database import database_url_from_env
@@ -130,15 +129,15 @@ DATABASES: dict = {}
 #     }
 
 if DATABASE_URL := env("DATABASE_CREDENTIALS", default=None):
-    DATABASES["default"] = dj_database_url.config(  # noqa
-        default=database_url_from_env("DATABASE_CREDENTIALS"),
-        engine="postgresql",
-    )
+    DATABASES["default"] = {
+        "NAME": database_url_from_env("DATABASE_CREDENTIALS"),
+        "ENGINE": "django.db.backends.postgresql",
+    }
 else:
-    DATABASES["default"] = dj_database_url.parse(
-        "{}",
-        engine="postgresql",
-    )
+    DATABASES["default"] = {
+        "NAME": "{}",
+        "ENGINE": "django.db.backends.postgresql",
+    }
 
 AUTH_PASSWORD_VALIDATORS = [
     {

--- a/fbr/settings.py
+++ b/fbr/settings.py
@@ -131,13 +131,12 @@ DATABASES: dict = {}
 
 if DATABASE_URL := env("DATABASE_CREDENTIALS", default=None):
     DATABASES["default"] = dj_database_url.config(  # noqa
-        default=database_url_from_env("DATABASE_CREDENTIALS")
+        default=database_url_from_env("DATABASE_CREDENTIALS"),
+        engine="postgresql",
     )
 else:
     DATABASES["default"] = dj_database_url.parse(
-        '{"pw":"postgres","dbname":"fbr","engine":"postgres",'
-        '"port":5432,"dbInstanceIdentifier":"xxx","host":"db",'
-        '"username":"postgres"}',
+        "{}",
         engine="postgresql",
     )
 


### PR DESCRIPTION
Added the "engine" parameter explicitly as "postgresql" when configuring the database URL. This ensures consistency and clarity in database connection handling. Simplified the default database URL parsing for cleaner fallbacks.