### PR TITLE
chore:increase Celery task time limit to 30 minutes

### DIFF
--- a/fbr/settings.py
+++ b/fbr/settings.py
@@ -197,7 +197,7 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers.DatabaseScheduler"
 CELERY_RESULT_EXTENDED = True
 CELERY_TASK_TIME_LIMIT = (
-    900  # Maximum runtime for a task in seconds (e.g., 900/60 = 15 minutes)
+    1800  # Maximum runtime for a task in seconds (e.g., 1800/60 = 30 minutes)
 )
 CELERY_TASK_SOFT_TIME_LIMIT = (
     270  # Optional: Grace period before forced termination


### PR DESCRIPTION
**Description:**
- Updated the `CELERY_TASK_TIME_LIMIT` from 15 minutes to 30 minutes for longer-running tasks.