### PR TITLE
remove:test_sentry endpoint from core views and URLs

### DIFF
--- a/app/core/views.py
+++ b/app/core/views.py
@@ -32,19 +32,6 @@ def home(request: HttpRequest) -> HttpResponse:
     return render(request, template_name="home.html", context=context)
 
 
-@require_http_methods(["GET"])
-def test_sentry(request):
-    import logging
-
-    logger = logging.getLogger(__name__)
-
-    logger.info("sentry: [INFO] find business regulations test message")
-    logger.error("sentry: [ERROR] find business regulations test message")
-    logger.warning("sentry: [WARNING] find business regulations test message")
-    logger.debug("sentry: [DEBUG] find business regulations test message")
-    return HttpResponse("Log message written", status=200)
-
-
 @require_safe
 def health_check(request: HttpRequest) -> HttpResponse:
     """Healthcheck endpoint.

--- a/fbr/urls.py
+++ b/fbr/urls.py
@@ -134,7 +134,6 @@ urlpatterns = [
         name="hide-cookie-banner",
     ),
     # path("search/", orp_views.search, name="search"),
-    path("test-sentry/", core_views.test_sentry, name="test-sentry"),
 ]
 
 if settings.DJANGO_ADMIN:


### PR DESCRIPTION
### Description
The `test_sentry` endpoint and its associated URL have been removed from core views and URLs as they are no longer needed. This cleanup helps eliminate unused code, improving maintainability and reducing potential clutter in the project.