### PR TITLE
fix: reorder cache-building tasks and extend Celery task time limit

### DIFF
--- a/celery_worker/tasks.py
+++ b/celery_worker/tasks.py
@@ -27,8 +27,8 @@ def rebuild_cache():
         start = time.time()
         clear_all_documents()
         config = SearchDocumentConfig(search_query="", timeout=2)
-        Legislation().build_cache(config)
         PublicGateway().build_cache(config)
+        Legislation().build_cache(config)
         end = time.time()
         message = {
             "message": "rebuilt cache",

--- a/fbr/settings.py
+++ b/fbr/settings.py
@@ -198,7 +198,7 @@ CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers.DatabaseScheduler"
 CELERY_RESULT_EXTENDED = True
 CELERY_TASK_TIME_LIMIT = (
-    1800  # Maximum runtime for a task in seconds (e.g., 1800/60 = 30 minutes)
+    3600  # Maximum runtime for a task in seconds (e.g., 3600/60 = 60 minutes)
 )
 CELERY_TASK_SOFT_TIME_LIMIT = (
     270  # Optional: Grace period before forced termination


### PR DESCRIPTION
**Description:**
Reordered cache-building tasks in `tasks.py` for correct execution sequence. Extended Celery task time limit to 60 minutes in `settings.py` to support longer processes.