### PR TITLE
hotfix/publisher-data-not-found

### DIFF
--- a/react_front_end/src/components/Results.js
+++ b/react_front_end/src/components/Results.js
@@ -51,8 +51,9 @@ function Results({ results, isLoading, searchQuery = "", publishers, onPublisher
         const { id, type, title, description, publisher, source_date_modified, source_date_issued, regulatory_topics } =
           result
 
-        const publisherName = publishers.find((publisherName) => publisherName.label === publisher).name
-        // const highlightedTitle = title ? <span dangerouslySetInnerHTML={highlight(title)} /> : ""
+        const publisherObj = publishers.find((pub) => pub.label === publisher)
+        const publisherName = publisherObj ? publisherObj.name : "Unknown publisher"
+
         const highlightedDescription = description ? truncateAndHighlightDescription(description) : ""
 
         return (


### PR DESCRIPTION
This pull request includes a small but important change to the `Results` component in the `react_front_end` project. The change improves the handling of publisher names when rendering search results.

Improvements to handling publisher names:

* [`react_front_end/src/components/Results.js`](diffhunk://#diff-f59e94855de12d963277e78c85626bc7a0f087d635f23255d2a1368145c4a6a9L54-R56): Modified the code to handle cases where the publisher is not found in the `publishers` list, ensuring that "Unknown publisher" is displayed instead of causing an error.