### PR TITLE
refactor(urls): reorganize document type results by category

### DIFF
--- a/fbr/urls.py
+++ b/fbr/urls.py
@@ -56,16 +56,47 @@ class PublishersViewSet(viewsets.ViewSet):
         try:
             publishers = get_publisher_names()
 
-            results = [
-                {
-                    "label": item["trimmed_publisher"],
-                    "name": item["trimmed_publisher_id"],
-                }
-                for item in publishers
-                if item
-                and item.get("trimmed_publisher") is not None
-                and item.get("trimmed_publisher_id") is not None
-            ]
+            # Separate standard/guidance from legislation items
+            standard_guidance_results = []
+            legislation_items = []
+
+            for item in publishers:
+                if (
+                    item
+                    and item.get("trimmed_publisher") is not None
+                    and item.get("trimmed_publisher_id") is not None
+                ):
+
+                    label = item["trimmed_publisher"].lower()
+                    if "standard" in label or "guidance" in label:
+                        # Add standard/guidance items individually
+                        standard_guidance_results.append(
+                            {
+                                "label": item["trimmed_publisher"],
+                                "name": item["trimmed_publisher_id"],
+                            }
+                        )
+                    else:
+                        # Add legislation items to a separate list
+                        legislation_items.append(
+                            {
+                                "label": item["trimmed_publisher"],
+                                "name": item["trimmed_publisher_id"],
+                            }
+                        )
+
+            # Combine results, with legislation items grouped under one object
+            results = standard_guidance_results
+
+            # Add legislation category with all legislation items
+            if legislation_items:
+                results.append(
+                    {
+                        "label": "Legislation",
+                        "name": "legislation",
+                        "items": legislation_items,
+                    }
+                )
 
             return Response(
                 data={"results": results},

--- a/fbr/urls.py
+++ b/fbr/urls.py
@@ -74,7 +74,8 @@ class DocumentTypesViewSet(viewsets.ViewSet):
                         word.capitalize() for word in doc_type.split()
                     )
 
-                # For camel case, insert spaces before capital letters and capitalize first letter
+                # For camel case, insert spaces before capital letters and
+                # capitalize first letter
                 formatted = re.sub(r"(?<!^)(?=[A-Z])", " ", doc_type)
                 return formatted
 

--- a/fbr/urls.py
+++ b/fbr/urls.py
@@ -50,53 +50,99 @@ class DataResponseViewSet(viewsets.ViewSet):
             )
 
 
+class DocumentTypesViewSet(viewsets.ViewSet):
+    @action(detail=False, methods=["get"], url_path="document-types")
+    def document_types(self, request, *args, **kwargs):
+        try:
+            import re
+
+            from django.db.models import F
+            from django.db.models.functions import Trim
+
+            from app.search.models import DataResponseModel
+
+            def format_document_type(doc_type):
+                """
+                Format document type string:
+                1. For camel case strings (like EuropeanUnionDecision),
+                   insert spaces between words
+                2. For strings with spaces, capitalize each word
+                """
+                # If already contains spaces, just capitalize each word
+                if " " in doc_type:
+                    return " ".join(
+                        word.capitalize() for word in doc_type.split()
+                    )
+
+                # For camel case, insert spaces before capital letters and capitalize first letter
+                formatted = re.sub(r"(?<!^)(?=[A-Z])", " ", doc_type)
+                return formatted
+
+            # Get all distinct document types from the DataResponseModel
+            document_types = (
+                DataResponseModel.objects.values(doc_type=Trim(F("type")))
+                .filter(type__isnull=False)
+                .exclude(type__exact="")
+                .distinct()
+                .order_by("doc_type")
+            )
+
+            # Categorize document types
+            non_legislation = []
+            legislation = []
+
+            for item in document_types:
+                if item and item.get("doc_type") is not None:
+                    doc_type = item["doc_type"]
+                    formatted_type = format_document_type(doc_type)
+                    display_item = {
+                        "label": formatted_type,
+                        "name": doc_type,
+                    }
+
+                    if (
+                        "standard" in doc_type.lower()
+                        or "guidance" in doc_type.lower()
+                    ):
+                        # Add to non-legislation
+                        non_legislation.append(display_item)
+                    else:
+                        # Add to legislation
+                        legislation.append(display_item)
+
+            # Create the response payload
+            response_data = {
+                "non-legislation": non_legislation,
+                "legislation": legislation,
+            }
+
+            return Response(
+                data=response_data,
+                status=status.HTTP_200_OK,
+            )
+        except Exception as e:
+            return Response(
+                data={"message": f"error fetching document types: {e}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+
 class PublishersViewSet(viewsets.ViewSet):
     @action(detail=False, methods=["get"], url_path="publishers")
     def publishers(self, request, *args, **kwargs):
         try:
             publishers = get_publisher_names()
 
-            # Separate standard/guidance from legislation items
-            standard_guidance_results = []
-            legislation_items = []
-
-            for item in publishers:
-                if (
-                    item
-                    and item.get("trimmed_publisher") is not None
-                    and item.get("trimmed_publisher_id") is not None
-                ):
-
-                    label = item["trimmed_publisher"].lower()
-                    if "standard" in label or "guidance" in label:
-                        # Add standard/guidance items individually
-                        standard_guidance_results.append(
-                            {
-                                "label": item["trimmed_publisher"],
-                                "name": item["trimmed_publisher_id"],
-                            }
-                        )
-                    else:
-                        # Add legislation items to a separate list
-                        legislation_items.append(
-                            {
-                                "label": item["trimmed_publisher"],
-                                "name": item["trimmed_publisher_id"],
-                            }
-                        )
-
-            # Combine results, with legislation items grouped under one object
-            results = standard_guidance_results
-
-            # Add legislation category with all legislation items
-            if legislation_items:
-                results.append(
-                    {
-                        "label": "Legislation",
-                        "name": "legislation",
-                        "items": legislation_items,
-                    }
-                )
+            results = [
+                {
+                    "label": item["trimmed_publisher"],
+                    "name": item["trimmed_publisher_id"],
+                }
+                for item in publishers
+                if item
+                and item.get("trimmed_publisher") is not None
+                and item.get("trimmed_publisher_id") is not None
+            ]
 
             return Response(
                 data={"results": results},
@@ -148,6 +194,9 @@ router = routers.DefaultRouter()
 
 router.register(r"v1", DataResponseViewSet, basename="search")
 router.register(r"v1/retrieve", PublishersViewSet, basename="publishers")
+router.register(
+    r"v1/retrieve", DocumentTypesViewSet, basename="document-types"
+)
 router.register(r"v1/cache", CacheViewSet, basename="cache")
 
 


### PR DESCRIPTION
Updated logic to separate publishers into "standard/guidance" and "legislation" categories. Grouped legislation items under a single object to streamline the response structure. This improves clarity and better aligns with data organization requirements.

Navigate to: `GET /api/v1/retrieve/document-types/` and you should see something similar to:
```
{
    "non-legislation": [
        {
            "label": "Guidance",
            "name": "Guidance"
        },
        {
            "label": "Standard",
            "name": "Standard"
        },
        {
            "label": "Statutory Guidance",
            "name": "Statutory guidance"
        }
    ],
    "legislation": [
        {
            "label": "European Union Decision",
            "name": "EuropeanUnionDecision"
        },
        {
            "label": "European Union Directive",
            "name": "EuropeanUnionDirective"
        },
        {
            "label": "European Union Regulations",
            "name": "EuropeanUnionRegulations"
        },
        {
            "label": "Northern Ireland Assembly Measure",
            "name": "NorthernIrelandAssemblyMeasure"
        },
        {
            "label": "Northern Ireland Statutory Rule",
            "name": "NorthernIrelandStatutoryRule"
        },
        {
            "label": "Scottish Statutory Instrument",
            "name": "ScottishStatutoryInstrument"
        },
        {
            "label": "United Kingdom Public General Act",
            "name": "UnitedKingdomPublicGeneralAct"
        },
        {
            "label": "United Kingdom Statutory Instrument",
            "name": "UnitedKingdomStatutoryInstrument"
        },
        {
            "label": "Welsh Statutory Instrument",
            "name": "WelshStatutoryInstrument"
        }
    ]
}
```